### PR TITLE
fix for out of memory problem

### DIFF
--- a/expdist_cuda.cpp
+++ b/expdist_cuda.cpp
@@ -1,20 +1,21 @@
 #include <stdio.h>
 #include "expdist.h"
 
+//declared as a global variable, so that it remains across
+//multiple invocations of expdist_cuda
+GPUExpDist *gpu_expdist = (GPUExpDist *)NULL;
+
 double expdist_cuda(const double* A, const double* B,
                             int m, int n, int dim, 
                             const double* scale_A,
                             const double* scale_B)
 {
 
-    GPUExpDist *gpu_expdist = (GPUExpDist *)NULL;
-
     if (gpu_expdist == (GPUExpDist *)NULL) {
         gpu_expdist = new GPUExpDist(1000000);
     }  
 
     double energy = gpu_expdist->compute(A, B, m, n, scale_A, scale_B);  
-    delete gpu_expdist;
 
     return energy;
 }


### PR DESCRIPTION
Hi Hamid, 

I've put the declaration of the gpu_expdist pointer outside of the function to make it a global variable that should persist across multiple invocations of the expdist_cuda function. In this way, the delete statement right after compute() is no longer necessary.

Best,
Ben